### PR TITLE
Display articles

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,8 +56,20 @@ function App() {
     } else if (currentPage !== 0) {
       setCurrentPage(0);
     } else {
-      fetchArticles();
+      fetchArticles().then(() => {
+        window.scroll(0, 0);
+      })
     }
+  }
+
+  const performKeywordSearch = keyword => {
+    const searchQuery = {
+      query: keyword,
+      beginDate: '',
+      endDate: ''
+    };
+    setSearchQuery(searchQuery);
+    submitNewSearch();
   }
 
   const fetchArticles = async () => {
@@ -128,7 +140,7 @@ function App() {
       <SearchResults
         isFetching={isFetching}
         articles={articles}
-        fetchArticles={fetchArticles}
+        performKeywordSearch={performKeywordSearch}
       />
     );
   }

--- a/src/Article.js
+++ b/src/Article.js
@@ -6,7 +6,7 @@ class Article extends React.Component {
     return (
       <li>
         <article>
-          <a target="_blank" className="headline-link">
+          <a href={this.props.article['web_url']} target="_blank" className="headline-link">
             <h2>{this.props.article.headline.main}</h2>
           </a>
           <p className="article-abstract">{this.props.article['pub_date']}</p>

--- a/src/Article.js
+++ b/src/Article.js
@@ -16,7 +16,10 @@ class Article extends React.Component {
           </a>
           <ArticleAbstract abstract={article.abstract} />
           <ArticleThumbnail thumbnail={article.multimedia.find(image => image.subtype === 'blog225')} />
-          <KeywordList keywords={article.keywords} />
+          <KeywordList 
+            keywords={article.keywords}
+            performKeywordSearch={this.props.performKeywordSearch}
+          />
           {/* <ul className="keywords"></ul> */}
         </article>
       </li>

--- a/src/Article.js
+++ b/src/Article.js
@@ -1,17 +1,23 @@
 import React from 'react';
 import Keyword from './Keyword';
+import ArticleAbstract from './ArticleAbstract';
+import ArticleThumbnail from './ArticleThumbnail';
+import KeywordList from './KeywordList';
 
 class Article extends React.Component {
   render() {
+    const article = this.props.article;
+
     return (
       <li>
         <article>
-          <a href={this.props.article['web_url']} target="_blank" className="headline-link">
-            <h2>{this.props.article.headline.main}</h2>
+          <a href={article.web_url} target="_blank" className="headline-link">
+            <h2>{article.headline.main}</h2>
           </a>
-          <p className="article-abstract">{this.props.article['pub_date']}</p>
-          <img className="article-img" />
-          <ul className="keywords"></ul>
+          <ArticleAbstract abstract={article.abstract} />
+          <ArticleThumbnail thumbnail={article.multimedia.find(image => image.subtype === 'blog225')} />
+          <KeywordList keywords={article.keywords} />
+          {/* <ul className="keywords"></ul> */}
         </article>
       </li>
     );

--- a/src/ArticleAbstract.js
+++ b/src/ArticleAbstract.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+function ArticleAbstract(props) {
+  if (props.abstract) {
+    return (
+      <p className="article-abstract">
+        {props.abstract}
+      </p>
+    );
+  } else {
+    return null;
+  }
+}
+
+export default ArticleAbstract;

--- a/src/ArticleThumbnail.js
+++ b/src/ArticleThumbnail.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+function ArticleThumbnail(props) {
+  if (props.thumbnail) {
+    return (
+      <img
+        src={`http://www.nytimes.com/${props.thumbnail.url}`} 
+        className="article-img"
+      />
+    );
+  } else {
+    return null;
+  }
+}
+
+export default ArticleThumbnail;

--- a/src/Keyword.js
+++ b/src/Keyword.js
@@ -1,13 +1,11 @@
 import React from "react";
 
-class Keyword extends React.Component {
-  render() {
-    return(
-      <li>
-        <a className="keyword" tabIndex="0">Keyword</a>
-      </li>
-    );
-  }
+function Keyword(props) {
+  return (
+    <li className="keyword" tabIndex="0">
+      <a>{props.keyword.value}</a>
+    </li>
+  );
 }
 
 export default Keyword;

--- a/src/Keyword.js
+++ b/src/Keyword.js
@@ -3,7 +3,9 @@ import React from "react";
 function Keyword(props) {
   return (
     <li className="keyword" tabIndex="0">
-      <a>{props.keyword.value}</a>
+      <a onClick={() => props.performKeywordSearch(props.keyword.value)}>
+        {props.keyword.value}
+      </a>
     </li>
   );
 }

--- a/src/KeywordList.js
+++ b/src/KeywordList.js
@@ -1,0 +1,23 @@
+import React from "react";
+import Keyword from "./Keyword";
+
+function KeywordList(props) {
+  if (props.keywords.length > 0) {
+    return (
+      <ul className="keywords">
+        {props.keywords.map((keyword, index) => {
+          return (
+            <Keyword 
+              key={index}
+              keyword={keyword}
+            />
+          );
+        })}
+      </ul>
+    );
+  } else {
+    return null;
+  }
+}
+
+export default KeywordList;

--- a/src/KeywordList.js
+++ b/src/KeywordList.js
@@ -10,6 +10,7 @@ function KeywordList(props) {
             <Keyword 
               key={index}
               keyword={keyword}
+              performKeywordSearch={props.performKeywordSearch}
             />
           );
         })}

--- a/src/SearchResults.js
+++ b/src/SearchResults.js
@@ -9,6 +9,7 @@ class SearchResults extends React.Component {
           <Article 
             key={article['_id']}
             article={article}
+            performKeywordSearch={this.props.performKeywordSearch}
           />
         )}
       </ul>


### PR DESCRIPTION
Hey @motine, the app now displays articles with all their content, and clicking a keyword performs a new search.

Here's the preview: https://matthewberglund.github.io/nytimes-article-searcher-react/

After this we only have two more features to implement before the React version is on par with the vanilla JS version:
1. Pagination when the user scrolls to the bottom of the page (infinite scrolling)
2. Storing the search data in the URL and performing the search on page refresh 